### PR TITLE
Add MetaContainer and MetaInformation

### DIFF
--- a/dalek/base/meta.py
+++ b/dalek/base/meta.py
@@ -92,11 +92,12 @@ class MetaInformation(object):
 
     @property
     def run_details(self):
-        res = {}
-        res['rank'] = self._rank
-        res['iteration'] = self._iteration
-        res['uuid'] = str(self._uuid)
-        res['fitness'] = 0
+        res = {
+                'rank': self._rank,
+                'iteration': self._iteration,
+                'uuid': str(self._uuid),
+                'fitness': self._fitness,
+                }
         try:
             for k,v in self._additional_data.items():
                 res[k] = v

--- a/dalek/base/meta.py
+++ b/dalek/base/meta.py
@@ -30,14 +30,15 @@ class MetaContainer(object):
         '''
         # TODO: proper dictionary to pd.Series parsing
         with self as store:
-            if 'summary' not in store.keys():
-                store.put('summary', pd.Series(data.values(), index=data.keys()))
+            if 'overview' not in store.keys():
+                store.put('overview', pd.Series(data.values(), index=data.keys()))
 
     def __enter__(self):
         '''
         Wrapper function to allow
-            with MetaContainer as store:
-                <code>
+
+        with MetaContainer as store:
+            <code>
         '''
         if not self.open:
             self.open = True
@@ -120,4 +121,4 @@ class MetaInformation(object):
     def save(self, container):
         with container as store:
             self._save_data(store)
-            store.append('summary', self.details)
+            store.append('run_table', self.details)

--- a/dalek/base/meta.py
+++ b/dalek/base/meta.py
@@ -1,0 +1,122 @@
+# coding: utf-8
+import os
+import pandas as pd
+from dalek.wrapper import SafeHDFStore
+import warnings
+import tables
+
+class MetaContainer(object):
+    """
+    Class to control storing of metainformation
+
+    Parameters
+    -----
+        path: string
+            Absolute path to output .h5 file
+        summary_data: dictionary-like object
+            Additional information that should be saved.
+            For example dalek_version, tardis_version, time, ranks, iterations
+
+    """
+    def __init__(self, path, summary_data=None):
+        self._path, self._file = os.path.split(path)
+        self.open = False
+        if summary_data is not None:
+            self._write_summary(summary_data)
+
+    def _write_summary(self, data):
+        '''
+        Write summary_data to .h5 file.
+        '''
+        # TODO: proper dictionary to pd.Series parsing
+        with self as store:
+            if 'summary' not in store.keys():
+                store.put('summary', pd.Series(data.values(), index=data.keys()))
+
+    def __enter__(self):
+        '''
+        Wrapper function to allow
+            with MetaContainer as store:
+                <code>
+        '''
+        if not self.open:
+            self.open = True
+            self.store = SafeHDFStore(os.path.join(self._path, self._file))
+        return self.store
+
+    def __exit__(self, type, value, traceback):
+        '''
+        close store after 'with'
+        '''
+        if self.open:
+            self.store.__exit__(type, value, traceback)
+            self.open = False
+        return
+
+
+
+class MetaInformation(object):
+
+    def __init__(self, uuid, rank, iteration, fitness, additional_data=None):
+        self._uuid = uuid
+        self._rank = rank
+        self._iteration = iteration
+        self._fitness = fitness
+        self._additional_data = additional_data
+        self._data = list()
+
+    @classmethod
+    def from_wrapper(cls, wrapper, parameter_dict):
+        mdl = wrapper.model
+        inst = cls(
+                uuid=wrapper.uuid,
+                rank=wrapper.rank,
+                iteration=wrapper.iteration,
+                fitness=wrapper.fitness,
+                additional_data=parameter_dict)
+        inst.add_data('spec',
+                pd.Series(mdl.spectrum.luminosity_density_lambda))
+        inst.add_data('spec_virt',
+                pd.Series(mdl.spectrum_virtual.luminosity_density_lambda))
+        inst.add_data('t_rads', pd.Series(mdl.t_rads))
+        inst.add_data('ws', pd.Series(mdl.ws))
+        return inst
+
+    def add_data(self, name, data):
+        self._data.append(name)
+        setattr(self, '_' + name, data)
+
+    def data_path(self, name=''):
+        return 'data/{}/{}'.format(self._uuid, name)
+
+
+    @property
+    def run_details(self):
+        res = {}
+        res['rank'] = self._rank
+        res['iteration'] = self._iteration
+        res['uuid'] = str(self._uuid)
+        res['fitness'] = 0
+        try:
+            for k,v in self._additional_data.items():
+                res[k] = v
+        except AttributeError:
+            pass
+        return res
+
+    @property
+    def details(self):
+        return (pd.DataFrame.from_records([self.run_details]).
+                    set_index(['iteration','rank']))
+
+
+    def _save_data(self, store):
+        warnings.simplefilter('ignore', tables.NaturalNameWarning)
+        for d in self._data:
+            getattr(self,'_' + d).to_hdf(store, self.data_path(d))
+
+
+    def save(self, container):
+        with container as store:
+            self._save_data(store)
+            store.append('summary', self.details)

--- a/dalek/base/test_meta.py
+++ b/dalek/base/test_meta.py
@@ -82,11 +82,11 @@ class TestMetaInformation(object):
         message = MetaInformation.from_wrapper(wrapper, parameter_dict)
         message.save(self.container)
         with self.container as store:
-            diff = store['summary'].loc[1,0] == message.details.loc[1,0]
+            diff = store['run_table'].loc[1,0] == message.details.loc[1,0]
             assert diff.all()
             #print(store)
             #print(store.keys())
-            #print(store['summary'])
+            #print(store['run_table'])
 
 
     # @pytest.mark.skipif(True, reason='debug')
@@ -99,12 +99,12 @@ class TestMetaInformation(object):
         message2 = MetaInformation.from_wrapper(wrapper, parameter_dict)
         message2.save(self.container)
         with self.container as store:
-            diff = store['summary'].loc[1,0] == message.details.loc[1,0]
-            diff2 = store['summary'].loc[2,0] == message2.details.loc[2,0]
+            diff = store['run_table'].loc[1,0] == message.details.loc[1,0]
+            diff2 = store['run_table'].loc[2,0] == message2.details.loc[2,0]
             assert diff.all()
             assert diff2.all()
             #print(store.keys())
             #print(store)
             #print(store.keys())
-            #print(store['summary'])
+            #print(store['run_table'])
 

--- a/dalek/base/test_meta.py
+++ b/dalek/base/test_meta.py
@@ -1,0 +1,110 @@
+import os
+import pytest
+import tempfile
+from uuid import uuid4
+import numpy as np
+import pandas as pd
+
+from dalek.base.meta import MetaContainer, MetaInformation
+
+class DummyRadial1D(object):
+
+    def __init__(self):
+        class Spectrum(object):
+            def __init__(self):
+                self.luminosity_density_lambda = np.random.random(10000)
+        self.t_rads = np.linspace(15000, 1000, 20)
+        self.ws = np.random.random(20)
+        self.spectrum = Spectrum()
+        self.spectrum_virtual = Spectrum()
+
+class DummyWrapper(object):
+
+    def __init__(self):
+        self.model = DummyRadial1D()
+        self.uuid = uuid4()
+        self.iteration = 1
+        self.rank = 0
+        self.fitness = 123
+
+class TestMetaContainer(object):
+
+    @classmethod
+    @pytest.fixture(scope='class', autouse=True)
+    def setup(self, request):
+        self._file = tempfile.NamedTemporaryFile()
+        self.container = MetaContainer(self._file.name)
+        def fin():
+            os.remove(self._file.name)
+        request.addfinalizer(fin)
+
+    def test_read_write(self):
+        tmp = pd.Series(np.arange(10))
+        with self.container as store:
+            store['s'] = tmp
+            print(store.filename)
+
+        with self.container as store:
+            print(store.filename)
+            assert np.all(tmp==store['s'].values)
+            del store['s']
+
+
+class TestMetaInformation(object):
+
+    @classmethod
+    @pytest.fixture(scope='function', autouse=True)
+    def setup(self, request):
+        self._file = tempfile.NamedTemporaryFile()
+        self.container = MetaContainer(self._file.name)
+
+    @pytest.fixture(scope='class')
+    def parameter_dict(self):
+        return {
+                'o': 0.1,
+                'o_raw' : 0.01
+                }
+
+
+    def test_init(self):
+        uuid = uuid4()
+        instance = MetaInformation(uuid, 0,1,2,{})
+        assert instance._rank == 0
+        assert instance._iteration == 1
+        assert instance._fitness == 2
+        assert instance._additional_data == {}
+        assert instance._uuid == uuid
+
+
+    # @pytest.mark.skipif(True, reason='debug')
+    def test_save(self, parameter_dict):
+        wrapper = DummyWrapper()
+        message = MetaInformation.from_wrapper(wrapper, parameter_dict)
+        message.save(self.container)
+        with self.container as store:
+            diff = store['summary'].loc[1,0] == message.details.loc[1,0]
+            assert diff.all()
+            #print(store)
+            #print(store.keys())
+            #print(store['summary'])
+
+
+    # @pytest.mark.skipif(True, reason='debug')
+    def test_save_multiple(self, parameter_dict):
+        wrapper = DummyWrapper()
+        message = MetaInformation.from_wrapper(wrapper, parameter_dict)
+        message.save(self.container)
+        wrapper = DummyWrapper()
+        wrapper.iteration = 2
+        message2 = MetaInformation.from_wrapper(wrapper, parameter_dict)
+        message2.save(self.container)
+        with self.container as store:
+            diff = store['summary'].loc[1,0] == message.details.loc[1,0]
+            diff2 = store['summary'].loc[2,0] == message2.details.loc[2,0]
+            assert diff.all()
+            assert diff2.all()
+            #print(store.keys())
+            #print(store)
+            #print(store.keys())
+            #print(store['summary'])
+

--- a/dalek/tools/base.py
+++ b/dalek/tools/base.py
@@ -95,7 +95,6 @@ class Chain(Chainable):
         return input_dict
 
     def cleanup(self, input_dict):
-        return {
-                name: input_dict.get(name) for name in self.outputs
-                }
-
+        output_dict = dict.fromkeys(self.outputs)
+        output_dict.update(input_dict)
+        return output_dict

--- a/dalek/tools/base.py
+++ b/dalek/tools/base.py
@@ -1,0 +1,101 @@
+from __future__ import print_function
+from copy import copy
+import sys
+
+def warning(*objs):
+    print("WARNING: ", *objs, file=sys.stderr)
+
+class BreakChainException(Exception):
+    pass
+
+class Chainable(object):
+    inputs = set()
+    outputs = set()
+
+    def __call__(self, data={}):
+        if self._isvalid(data):
+            data = self._apply(copy(data))
+        else:
+            raise ValueError("Inputs required are: {}\n Data provides only: {}".format(
+                str(self.inputs),
+                str(data)
+                ))
+        return data
+
+    def _isvalid(self, data):
+        try:
+            valid = self.inputs.issubset(data.keys())
+        except AttributeError:
+            valid = set(self.inputs).issubset(data.keys())
+        finally:
+            return valid
+
+class Link(Chainable):
+
+    def _apply(self, input_dict):
+        inputs = self._prepare_input(input_dict)
+        output = self.calculate(*inputs)
+        # output_dict = copy(input_dict)
+        output = self._prepare_output(output)
+        input_dict.update(output)
+        return input_dict
+
+    def _prepare_input(self, input_dict):
+        output = []
+        for i in self.inputs:
+            output.append(input_dict[i])
+        return output
+
+    def _prepare_output(self, output):
+        '''
+        Possible inputs:
+        - None : Link doesn't output
+        - One element : Link has one output
+        - Tuple
+        '''
+        if len(self.outputs) == 0:
+            return {}
+        if len(self.outputs) == 1:
+            return { self.outputs[0]: output }
+        if len(output) == len(self.outputs):
+            return dict(zip(self.outputs, output))
+        else:
+            raise ValueError(
+                    "{} is expected to return {} but actual value was {}".format(
+                        self.__class__.__name__, (self.outputs), str(output)))
+
+
+class Chain(Chainable):
+
+    def __init__(self, *args, **kwargs):
+        try:
+            self.breakable = kwargs.pop('breakable')
+        except KeyError:
+            self.breakable = False
+        self._links = list()
+        self.inputs = set()
+        self.outputs = set()
+        for arg in args:
+            self._links.append(arg)
+            self.inputs.update(set(arg.inputs).difference(self.outputs))
+            self.outputs.update(arg.outputs)
+        self.outputs.update(self.inputs)
+        super(Chain, self).__init__()
+
+    def _apply(self, input_dict):
+        for link in self._links:
+            try:
+                input_dict = link(input_dict)
+            except BreakChainException as e:
+                if self.breakable:
+                    input_dict = self.cleanup(input_dict)
+                    break
+                else:
+                    raise e
+        return input_dict
+
+    def cleanup(self, input_dict):
+        return {
+                name: input_dict.get(name) for name in self.outputs
+                }
+

--- a/dalek/tools/compositions.py
+++ b/dalek/tools/compositions.py
@@ -1,0 +1,34 @@
+from astropy import units as u
+from dalek.tools.base import Chain
+
+from dalek.tools.model import Tardis
+from dalek.tools.prior import Prior, CheckPrior
+from dalek.tools.posterior import Posterior
+from dalek.tools.providers import (
+        VirtualPacketProvider,
+        VirtualLuminosity,
+        Flux,
+        RunInfo
+        )
+from dalek.tools.likelihood import SSum
+
+
+class SimpleTardis(Chain):
+
+    def __init__(self, wrapper, observed_wl, observed_flux, distance=(1 * u.Mpc)):
+        # Make sure we are dealing with bin edges, not centers
+        assert len(observed_wl) == len(observed_flux) + 1
+        super(SimpleTardis, self).__init__(
+                RunInfo(),
+                Prior(),
+                Chain(
+                    CheckPrior(),
+                    Tardis(wrapper),
+                    VirtualPacketProvider(),
+                    VirtualLuminosity(observed_wl),
+                    Flux(distance),
+                    SSum(observed_wl, observed_flux),
+                    breakable=True
+                    ),
+                Posterior(),
+                )

--- a/dalek/tools/conftest.py
+++ b/dalek/tools/conftest.py
@@ -1,0 +1,23 @@
+import pytest
+import logging
+
+from tardis import run_tardis
+logging.getLogger('tardis').setLevel(logging.ERROR)
+
+
+
+
+@pytest.fixture(scope='module')
+def config_path():
+    return "/home/stefan/projects/dalek/data/wrapper-test/quick_test.yml"
+
+
+@pytest.fixture(scope='module')
+def log_path():
+    return "/home/stefan/projects/dalek/data/wrapper-test/test/logs/"
+
+
+
+@pytest.fixture(scope='module')
+def model(config_path):
+    return run_tardis(config_path)

--- a/dalek/tools/likelihood.py
+++ b/dalek/tools/likelihood.py
@@ -1,0 +1,44 @@
+import numpy as np
+
+from dalek.tools.base import Link
+
+
+# class BaseLikelihoodModel(object):
+#
+#     def __init__(self, tardis_model, log_fname, spec_dir=None):
+#         self.tardis_model = tardis_model
+#         self.log_fname = log_fname
+#         self.spec_dir = spec_dir
+#
+#     def __call__(self, *args, **kwargs):
+#
+#         transformed_params = self.transform(*args)
+#         priors = self.calculate_priors(*transformed_params)
+#
+#         if np.isinf(priors):
+#             loglikelihood = -0.5 * np.inf
+#         else:
+#             loglikelihood = self.tardis_model.evaluate(*transformed_params)
+#
+#         properties_dict = dict(transformed_params=transformed_params)
+#         return loglikelihood, properties_dict
+
+class SSum(Link):
+    inputs = ('flux',)
+    outputs = ('loglikelihood',)
+
+    def __init__(self, wl, flux, start=0, end=np.inf):
+        if len(wl) == len(flux) + 1:
+            # convert bin edges to bin centers
+            wl = (wl[1:] + wl[:-1]) / 2
+        self._slice = slice(
+                wl.searchsorted(start),
+                wl.searchsorted(end) + 1
+                )
+        self._observed_flux = flux.to('erg / ( Angstrom cm2 s )')
+
+    def calculate(self, flux):
+        return -0.5 * np.sum(
+                (self._observed_flux[self._slice] -
+                flux[self._slice])**2)
+

--- a/dalek/tools/model.py
+++ b/dalek/tools/model.py
@@ -21,6 +21,5 @@ class Tardis(Link):
                 config.set_config_item(k, v)
             return config
 
-        self._wrapper.set_logger(uuid)
-        mdl = self._wrapper(apply_config)
+        mdl = self._wrapper(apply_config, log_name=uuid)
         return mdl

--- a/dalek/tools/model.py
+++ b/dalek/tools/model.py
@@ -1,0 +1,26 @@
+from dalek.tools.base import Link
+from dalek.wrapper.tardis_wrapper import TardisWrapper
+
+
+class Tardis(Link):
+    inputs = ('parameters', 'uuid',)
+    outputs = ('model',)
+
+    def __init__(self, wrapper):
+        if not isinstance(wrapper, TardisWrapper):
+            raise ValueError(
+                    "expected an instance of TardisWrapper, got: {}".format(
+                        str(type(wrapper)))
+                    )
+        self._wrapper = wrapper
+
+    def calculate(self, parameters, uuid):
+
+        def apply_config(config):
+            for k, v in parameters.items():
+                config.set_config_item(k, v)
+            return config
+
+        self._wrapper.set_logger(uuid)
+        mdl = self._wrapper(apply_config)
+        return mdl

--- a/dalek/tools/parameters.py
+++ b/dalek/tools/parameters.py
@@ -141,7 +141,12 @@ class ParameterContainer(object):
     def __getitem__(self, name):
         for p in self._parameters:
             if p.path == name:
-                return p
+                return p.value
 
     def items(self):
+        for p in self._parameters:
+            yield p.path, p.value
+
+    @property
+    def dict(self):
         return {p.path: p.value for p in self._parameters}

--- a/dalek/tools/parameters.py
+++ b/dalek/tools/parameters.py
@@ -1,0 +1,102 @@
+class Parameter(object):
+
+    def __init__(self, path, bounds=(0,1), default=0,
+            transformation=lambda x, a, b : a + x * (b-a)):
+        self._bounds = bounds
+        self._transform = transformation
+        self.path = path
+        self.value = default
+
+    @property
+    def value(self):
+        return self._value
+
+    @value.setter
+    def value(self, new):
+        self._value = self.transform(new)
+
+    def transform(self, x):
+        if x>1 or x<0:
+            raise ValueError(
+            'Parameter.transform: expected input is [0,1]. Received: {}'
+            .format(x))
+        else:
+            return self._transform(x, self._bounds[0], self._bounds[1])
+
+    @property
+    def name(self):
+        return self.path.split('.')[-1]
+
+    @property
+    def base_path(self):
+        return '.'.join(self.path.split('.')[:-1])
+
+
+class CalculatedParameter(Parameter):
+# This is kind of hacky, sorry
+    pass
+
+
+class OverFlowParameter(CalculatedParameter):
+
+    def __init__(self, path, bounds=(0,1)):
+        self._bounds = bounds
+        self.path = path
+        self._value = bounds[0]
+
+    @property
+    def value(self):
+        return self._value
+
+    @value.setter
+    def value(self, container):
+        parameters = container._parameters
+        value = self._bounds[1]
+        for p in parameters:
+            if p.base_path == self.base_path:
+                value -= p.value
+        if value > self._bounds[0] and value < self._bounds[1]:
+            self._value = value
+        else:
+            raise ValueError(
+                    'OverFlowParameter is out of bounds: {} is outside of {}'
+                    .format(value, self._bounds))
+
+
+class ParameterContainer(object):
+    n_pars=0
+
+    def __init__(self, *args, **kwargs):
+        self._parameters = []
+        for arg in args:
+            if isinstance(arg, Parameter):
+                setattr(self, arg.name, arg)
+                self.n_pars += 1
+                self._parameters.append(arg)
+
+    def __iter__(self):
+        for p in self._parameters:
+            yield p.path, p.value
+
+    @property
+    def values(self):
+        return [ p.value for p in self._parameters]
+
+    @values.setter
+    def values(self, new):
+        calc_pars = list()
+        for p in self._parameters:
+            try:
+                p.value = new[0]
+            except AttributeError:
+                # Seems like a CalcParameter
+                calc_pars.append(p)
+            except IndexError as e:
+                if p == self._parameters[-1]:
+                    calc_pars.append(p)
+                else:
+                    raise e
+            else:
+                new.pop(0)
+        for p in calc_pars:
+            p.value = self

--- a/dalek/tools/parameters.py
+++ b/dalek/tools/parameters.py
@@ -1,11 +1,46 @@
 class Parameter(object):
+    """
+    A static Parameter whose value can't be changed.
 
-    def __init__(self, path, bounds=(0,1), default=0,
-            transformation=lambda x, a, b : a + x * (b-a)):
-        self._bounds = bounds
-        self._transform = transformation
+    Make sure to change the default value of 0.0 during initialization.
+    """
+
+    def __init__(self, path, default=0.0):
         self.path = path
-        self.value = default
+        self._value = default
+
+    @property
+    def value(self):
+        return self._value
+
+    @property
+    def name(self):
+        return self.path.split('.')[-1]
+
+    @property
+    def base_path(self):
+        return '.'.join(self.path.split('.')[:-1])
+
+    @property
+    def full_name(self):
+        return '_'.join(self.path.split('.'))
+
+
+
+class DynamicParameter(Parameter):
+    """
+    A Parameter whose value can be updated and transformed with a function.
+
+    Keyword arguments:
+    bounds -- Tuple of lower and upper bounds of the result (default: (0,1) )
+    transformation -- function f(x, bounds[0], bounds[1]) mapping [0,1]
+                        onto the bounds interval (default: linear map)
+    """
+
+    def __init__(self, *args, **kwargs):
+        self._ftransform = kwargs.pop('transformation', lambda x, a, b : a + x * (b-a))
+        self._bounds = kwargs.pop('bounds', (0,1))
+        super(DynamicParameter, self).__init__(*args, **kwargs)
 
     @property
     def value(self):
@@ -21,28 +56,29 @@ class Parameter(object):
             'Parameter.transform: expected input is [0,1]. Received: {}'
             .format(x))
         else:
-            return self._transform(x, self._bounds[0], self._bounds[1])
-
-    @property
-    def name(self):
-        return self.path.split('.')[-1]
-
-    @property
-    def base_path(self):
-        return '.'.join(self.path.split('.')[:-1])
+            return self._ftransform(x, self._bounds[0], self._bounds[1])
 
 
-class CalculatedParameter(Parameter):
-# This is kind of hacky, sorry
-    pass
+class DependentParameter(Parameter):
+    """
+    A Parameter that depends on the value of other parameters.
+
+    It's value gets updated after other parameters.
+    Currently two parameters depending on each other results in unexpected
+    behavior and should be avoided.
+    Subclasses should define an update(self, parameters) function to return
+    the new value.
+
+    Keyword arguments:
+    bounds -- Tuple of lower and upper bounds of the result (default: (0,1) )
+    """
 
 
-class OverFlowParameter(CalculatedParameter):
-
-    def __init__(self, path, bounds=(0,1)):
-        self._bounds = bounds
-        self.path = path
-        self._value = bounds[0]
+    def __init__(self, *args, **kwargs):
+        self._bounds = kwargs.pop('bounds', (0,1))
+        match = kwargs.pop('match', None)
+        super(DependentParameter, self).__init__(*args, **kwargs)
+        self._match_string = match or self.base_path
 
     @property
     def value(self):
@@ -51,12 +87,18 @@ class OverFlowParameter(CalculatedParameter):
     @value.setter
     def value(self, container):
         parameters = container._parameters
+        self._value = self.update(parameters)
+
+
+class OverFlowParameter(DependentParameter):
+
+    def update(self, parameters):
         value = self._bounds[1]
         for p in parameters:
-            if p.base_path == self.base_path:
+            if p.base_path == self._match_string:
                 value -= p.value
         if value > self._bounds[0] and value < self._bounds[1]:
-            self._value = value
+            return value
         else:
             raise ValueError(
                     'OverFlowParameter is out of bounds: {} is outside of {}'
@@ -68,15 +110,17 @@ class ParameterContainer(object):
 
     def __init__(self, *args, **kwargs):
         self._parameters = []
+        self._input_pars = []
+        self._dep_pars = []
         for arg in args:
             if isinstance(arg, Parameter):
-                setattr(self, arg.name, arg)
+                setattr(self, arg.full_name, arg)
                 self.n_pars += 1
                 self._parameters.append(arg)
-
-    def __iter__(self):
-        for p in self._parameters:
-            yield p.path, p.value
+                if isinstance(arg, DynamicParameter):
+                    self._input_pars.append(arg)
+                elif isinstance(arg, DependentParameter):
+                    self._dep_pars.append(arg)
 
     @property
     def values(self):
@@ -84,19 +128,20 @@ class ParameterContainer(object):
 
     @values.setter
     def values(self, new):
-        calc_pars = list()
-        for p in self._parameters:
-            try:
-                p.value = new[0]
-            except AttributeError:
-                # Seems like a CalcParameter
-                calc_pars.append(p)
-            except IndexError as e:
-                if p == self._parameters[-1]:
-                    calc_pars.append(p)
-                else:
-                    raise e
-            else:
-                new.pop(0)
-        for p in calc_pars:
+        assert len(new) == len(self._input_pars)
+        for p, v in zip(self._input_pars, new):
+            p.value = v
+        for p in self._dep_pars:
             p.value = self
+
+    def __iter__(self):
+        for p in self._parameters:
+            yield p.path, p.value
+
+    def __getitem__(self, name):
+        for p in self._parameters:
+            if p.path == name:
+                return p
+
+    def items(self):
+        return {p.path: p.value for p in self._parameters}

--- a/dalek/tools/posterior.py
+++ b/dalek/tools/posterior.py
@@ -7,8 +7,8 @@ class Posterior(Link):
 
     def calculate(self, prior, likelihood):
         try:
-            return prior + likelihood
-        except TypeError as e:
+            return prior + likelihood.value
+        except (TypeError, AttributeError) as e:
             if likelihood is None:
                 return prior
             else:

--- a/dalek/tools/posterior.py
+++ b/dalek/tools/posterior.py
@@ -1,0 +1,15 @@
+from dalek.tools.base import Link
+
+
+class Posterior(Link):
+    inputs = ('logprior', 'loglikelihood',)
+    outputs = ('posterior',)
+
+    def calculate(self, prior, likelihood):
+        try:
+            return prior + likelihood
+        except TypeError as e:
+            if likelihood is None:
+                return prior
+            else:
+                raise e

--- a/dalek/tools/prior.py
+++ b/dalek/tools/prior.py
@@ -1,0 +1,48 @@
+import numpy as np
+
+from dalek.tools.base import Link, BreakChainException
+
+INVALID = -np.inf
+DEFAULT = 0
+
+class Prior(Link):
+    '''
+    A very basic prior with the ability to break execution of a subchain.
+    '''
+    inputs = ('parameters',)
+    outputs = ('logprior',)
+
+    def calculate(self, parameters):
+        try:
+            o = parameters['model.abundances.o']
+        except KeyError:
+            pass
+        else:
+            if o <= 0.:
+                return INVALID
+        try:
+            s = parameters['model.abundances.s']
+            si = parameters['model.abundances.si']
+        except KeyError:
+            pass
+        else:
+            if s > si:
+                return INVALID
+        return DEFAULT
+
+
+class CheckPrior(Link):
+    '''
+    This will break the innermost dalek.tools.base.Chain to save computing time
+    if the prior is INVALID.
+    This should be the first element in the Chain containing the Tardis
+    evaluation.
+    '''
+    inputs = ('logprior',)
+
+    def calculate(self, prior):
+        if prior == INVALID:
+            raise BreakChainException(
+                    'Prior is INVALID: {}'.format(prior))
+
+

--- a/dalek/tools/prior.py
+++ b/dalek/tools/prior.py
@@ -3,7 +3,7 @@ import numpy as np
 from dalek.tools.base import Link, BreakChainException
 
 INVALID = -np.inf
-DEFAULT = 0
+DEFAULT = 0.0
 
 class Prior(Link):
     '''

--- a/dalek/tools/providers.py
+++ b/dalek/tools/providers.py
@@ -1,0 +1,81 @@
+import numpy as np
+from uuid import uuid4
+from astropy import units as u
+
+from dalek.tools.base import Link
+
+
+class PacketProvider(Link):
+    inputs = ('model',)
+    outputs = ('packet_nu', 'packet_energy',)
+
+    def calculate(self, model):
+        return (
+                model.runner.emitted_packet_nu,
+                model.runner.emitted_packet_luminosity,
+                )
+
+
+class VirtualPacketProvider(Link):
+    inputs = ('model',)
+    outputs = ('virtual_packet_nu', 'virtual_packet_energy',)
+
+    def calculate(self, model):
+        return (
+                model.runner.virt_packet_nus * u.Hz,
+                model.runner.virt_packet_energies /
+                model.runner.time_of_simulation * u.erg,
+                )
+
+
+class Luminosity(Link):
+    inputs = ('packet_nu', 'packet_energy',)
+    outputs = ('luminosity',)
+
+    def __init__(self, wl):
+        self._wl_bins = wl
+
+    def calculate(self, nu, energy):
+        return (np.histogram(
+            nu.to(u.angstrom, u.spectral()),
+            weights=energy,
+            bins=self._wl_bins)[0] * energy.unit  / np.diff(self._wl_bins)
+            )
+
+
+class VirtualLuminosity(Luminosity):
+    inputs = ('virtual_packet_nu', 'virtual_packet_energy',)
+
+
+class Flux(Link):
+    inputs = ('luminosity',)
+    outputs = ('flux',)
+
+    def __init__(self, distance=(1 * u.Mpc)):
+        self._distance = distance.to('cm')
+
+    def calculate(self, lum):
+        print(lum.unit)
+        return lum / (4 * np.pi * self._distance**2)
+
+
+class RunInfo(Link):
+    inputs = tuple()
+    outputs = ('iteration', 'rank', 'uuid',)
+
+    def __init__(self):
+        self._iteration = 0
+        try:
+            from mpi4py import MPI
+        except ImportError:
+            self._rank = 0
+        else:
+            self._rank = MPI.COMM_WORLD.Get_rank()
+
+    def calculate(self):
+        self._iteration += 1
+        return (
+                self._iteration,
+                self._rank,
+                uuid4()
+                )

--- a/dalek/tools/providers.py
+++ b/dalek/tools/providers.py
@@ -55,7 +55,6 @@ class Flux(Link):
         self._distance = distance.to('cm')
 
     def calculate(self, lum):
-        print(lum.unit)
         return lum / (4 * np.pi * self._distance**2)
 
 

--- a/dalek/tools/test_base.py
+++ b/dalek/tools/test_base.py
@@ -1,0 +1,166 @@
+import numpy as np
+import pytest
+from dalek.tools.base import Link, Chain, BreakChainException
+
+
+class AppleTrue(Link):
+    outputs = ['apple']
+    def calculate(self):
+        return True
+
+
+class AppleToggle(Link):
+    inputs = ['apple']
+    outputs = ['apple']
+    def calculate(self, apple):
+        return not apple
+
+
+class BananaTrue(Link):
+    outputs = ['banana']
+    def calculate(self):
+        return True
+
+
+class BananaToggle(Link):
+    inputs = ['banana']
+    outputs = ['banana']
+    def calculate(self, banana):
+        return not banana
+
+
+class CherryAnd(Link):
+    inputs = ['apple', 'banana']
+    outputs = ['cherry']
+    def calculate(self, apple, banana):
+        return apple and banana
+
+
+class AppleBreak(Link):
+    inputs = ['apple']
+    outputs = ['apple']
+    def calculate(self, apple):
+        if apple:
+            raise BreakChainException
+        else:
+            return False
+
+class ApplePie(Link):
+    outputs = ['apple', 'pie']
+
+    def calculate(self):
+        return (
+                True,
+                False
+                )
+
+
+class NumpyReturn(Link):
+    outputs = ('array',)
+
+    def calculate(self):
+        return np.arange(10)
+
+
+@pytest.fixture
+def apple():
+    return AppleTrue()
+
+
+@pytest.fixture
+def apple_t():
+    return AppleToggle()
+
+
+@pytest.fixture
+def banana():
+    return BananaTrue()
+
+
+@pytest.fixture
+def banana_t():
+    return BananaToggle()
+
+
+@pytest.fixture
+def cherry_a():
+    return CherryAnd()
+
+def test_chainable(apple, apple_t):
+    assert apple({}) == apple()
+    assert apple._isvalid({})
+    assert not apple_t._isvalid({})
+
+
+def test_apple_true(apple):
+    assert apple({}) == {'apple': True}
+
+def test_apple_toggle(apple_t):
+    result = apple_t({'apple': False})
+    assert  result == {'apple': True}
+    with pytest.raises(ValueError):
+        apple_t({})
+
+def test_multi_chain(apple, banana):
+    assert Chain(apple)({}) == apple({})
+    chain = Chain(apple, banana)
+    assert chain() == {'apple':True, 'banana':True}
+
+def test_chain(apple, apple_t, banana, banana_t, cherry_a):
+    input_dict = {
+        'apple': False,
+        'banana': True
+        }
+    chain = Chain(apple_t, cherry_a, banana_t)
+    result = chain(input_dict)
+    assert result == {
+        'banana': False,
+        'apple': True,
+        'cherry': True,
+        }
+    assert Chain(chain, cherry_a)(input_dict) == {
+        'banana': False,
+        'apple': True,
+        'cherry': False,
+        }
+    with pytest.raises(ValueError):
+        chain({})
+        chain({'banana':False})
+        chain({'apple':False})
+
+def test_chain_init(apple, banana, cherry_a):
+    chain = Chain(apple, banana, cherry_a)
+    assert chain.inputs == set()
+    assert chain.outputs == set(['apple', 'banana', 'cherry'])
+    assert Chain(apple, cherry_a).inputs == set(['banana'])
+    assert Chain(apple, cherry_a).outputs  == set(['apple', 'banana', 'cherry'])
+
+def test_breakable_chain(apple, apple_t, banana, banana_t):
+    cond = AppleBreak()
+    Chain(apple, apple_t, cond, banana)()
+    with pytest.raises(BreakChainException):
+        Chain(apple, banana, cond, banana_t)()
+    assert Chain(apple, banana, cond, banana_t, breakable=True)() == {
+            'apple': True,
+            'banana': True
+            }
+    assert Chain(apple, banana, apple_t, cond, banana_t, breakable=True)() == {
+            'apple': False,
+            'banana': False
+            }
+
+    assert Chain(apple, cond, banana, breakable=True)() == {
+            'apple': True,
+            'banana': None
+            }
+
+def test_applepie():
+    ap = ApplePie()
+    assert ap() == {
+            'apple': True,
+            'pie': False
+            }
+
+def test_numpy():
+    nparray = NumpyReturn()
+    assert np.all(nparray()['array'] == np.arange(10))

--- a/dalek/tools/test_compositions.py
+++ b/dalek/tools/test_compositions.py
@@ -1,0 +1,42 @@
+import pytest
+import numpy as np
+from astropy import units as u
+
+from dalek.util import bin_center_to_edge
+from dalek.wrapper.tardis_wrapper import TardisWrapper
+from dalek.tools.base import Chain
+from dalek.tools.compositions import SimpleTardis
+from dalek.tools.providers import RunInfo
+
+
+@pytest.fixture
+def artis_path():
+    return "/home/stefan/projects/dalek/data/wrapper-test/aaflux_057.dat"
+
+
+@pytest.fixture
+def artisw(artis_path):
+    wl, _ = np.loadtxt(artis_path, unpack=True)
+    return bin_center_to_edge(wl) * u.angstrom
+
+
+@pytest.fixture
+def artisf(artis_path):
+    _, artisf = np.loadtxt(artis_path, unpack=True)
+    return artisf * u.erg / (u.cm**2) / u.angstrom / u.s
+
+
+def test_tardis(config_path, log_path, artisw, artisf):
+    wrapper = TardisWrapper(config_path, log_dir=log_path)
+
+    parameters = {
+            'model.abundances.o': 0.1,
+            }
+
+    chain = Chain(RunInfo(), SimpleTardis(wrapper, artisw, artisf))
+    output = chain(
+            {
+                'parameters': parameters
+                }
+            )
+    print(output['flux'])

--- a/dalek/tools/test_model.py
+++ b/dalek/tools/test_model.py
@@ -1,0 +1,21 @@
+from dalek.tools.base import Chain
+from dalek.tools.providers import RunInfo
+from dalek.tools.model import Tardis
+from dalek.wrapper.tardis_wrapper import TardisWrapper
+
+
+def test_tardis(config_path, log_path):
+    wrapper = TardisWrapper(config_path, log_dir=log_path)
+
+    parameters = {
+            'model.abundances.o': 0,
+            }
+
+    chain = Chain(RunInfo(), Tardis(wrapper))
+    output = chain(
+            {
+                'parameters': parameters
+                }
+            )
+    print(output.keys())
+

--- a/dalek/tools/test_parameters.py
+++ b/dalek/tools/test_parameters.py
@@ -1,0 +1,57 @@
+import sys
+import pytest
+from dalek.tools.parameters import (
+        Parameter, ParameterContainer,
+        OverFlowParameter,
+        )
+
+
+@pytest.mark.parametrize(
+        ['bounds'],
+        [
+            ((0,10),),
+            ((10,20),),
+            ]
+        )
+def test_parameter(bounds):
+    a = Parameter('c.b.a', bounds=bounds, default=0.5)
+    assert a.name == 'a'
+    assert a.base_path == 'c.b'
+    assert a.value == 5 + bounds[0]
+    a.value = 0.1
+    assert a.value == 1 + bounds[0]
+    assert a.transform(0) == bounds[0]
+    assert a.transform(1) == bounds[1]
+    with pytest.raises(ValueError):
+        a.value=1.1
+
+    b = Parameter('test')
+    assert b.name == 'test'
+    assert b.base_path == ''
+    assert b.path == 'test'
+
+
+def test_parameter_function():
+    a = Parameter('test', transformation = lambda x, a, b: x/(1-x+sys.float_info.min))
+    assert a.transform(0.5) == 1
+
+
+def test_container():
+    cont = ParameterContainer(
+            Parameter('a.b.c', bounds=(0, 0.2)),
+            Parameter('c.b.a', bounds=(0,0.8)),
+            OverFlowParameter('a.b.overflow'),
+            )
+    def overflow(x,a,b):
+        return 1 - cont.a.value - cont.b.value
+    assert isinstance(cont.a, Parameter)
+    assert cont.a.value == 0
+
+    cont.values = [0.5, 0.3]
+    cont = ParameterContainer(
+            OverFlowParameter('a.b.overflow'),
+            Parameter('a.b.c', bounds=(0, 0.2)),
+            Parameter('c.b.a', bounds=(0,0.8)),
+            )
+    cont.values = [0.5, 0.3]
+

--- a/dalek/tools/test_parameters.py
+++ b/dalek/tools/test_parameters.py
@@ -65,3 +65,5 @@ def test_container():
             )
     cont.values = [0.5, 0.3]
     assert cont.values == [0.9, 0.1, 0.24]
+    with pytest.raises(AssertionError):
+        cont.values = [1]

--- a/dalek/tools/test_prior.py
+++ b/dalek/tools/test_prior.py
@@ -1,0 +1,43 @@
+import pytest
+from dalek.tools.prior import Prior, CheckPrior, INVALID
+from dalek.tools.base import Chain, Link
+
+
+class Dummy(Link):
+    outputs = ('dummy',)
+
+    def calculate(self):
+        return True
+
+prior_pars = pytest.mark.parametrize(
+        ['o', 'expected'],
+        [
+            (0, INVALID),
+            (0.1, 0),
+            ]
+        )
+@prior_pars
+def test_prior(o, expected):
+    idict = {
+            'parameters': {
+                'model.abundances.o': o,
+                },
+            }
+
+    prior = Prior()
+    obtained = prior(idict)['logprior']
+    assert obtained == expected
+
+
+@prior_pars
+def test_checkprior(o, expected):
+    idict = {
+            'parameters': {
+                'model.abundances.o': o,
+                },
+            }
+
+    prior = Chain(Prior(), Chain(CheckPrior(), Dummy(), breakable=True))
+    obtained = prior(idict)['dummy']
+    expected = True if expected == 0 else None
+    assert obtained == expected

--- a/dalek/tools/test_providers.py
+++ b/dalek/tools/test_providers.py
@@ -1,0 +1,91 @@
+import pytest
+import numpy as np
+from astropy import units as u
+
+from dalek.tools.providers import (
+        PacketProvider, VirtualPacketProvider,
+        Luminosity, VirtualLuminosity,
+        Flux,
+        )
+from dalek.tools.base import Chain
+
+
+@pytest.fixture
+def input_dict(model):
+    return {
+            'model': model
+            }
+
+
+@pytest.fixture
+def vmodel(model):
+    if not hasattr(model.runner, 'virt_packet_nus'):
+        pytest.skip(reason="No virtual data present in model")
+    return model
+
+@pytest.fixture
+def bins(model):
+    return model.tardis_config.spectrum.frequency.to(
+            u.angstrom, u.spectral())[::-1].value
+
+
+def test_packet_provider(input_dict, model):
+    # print pprovider(input_dict)
+    pprovider = PacketProvider()
+    result = pprovider(input_dict)
+    assert np.all(
+            result['packet_energy'] ==
+            model.runner.emitted_packet_luminosity)
+    assert np.all(
+            result['packet_nu'] ==
+            model.runner.emitted_packet_nu)
+    assert result['packet_nu'].unit.is_equivalent('Hz')
+    assert result['packet_energy'].unit.is_equivalent('erg/s')
+
+
+def test_vpacket_provider(input_dict, vmodel):
+    vprovider = VirtualPacketProvider()
+    result = vprovider({'model': vmodel})
+    assert np.all(
+            result['virtual_packet_energy'] ==
+            vmodel.runner.virt_packet_energies * u.erg /
+            vmodel.runner.time_of_simulation)
+    assert np.all(
+            result['virtual_packet_nu'] ==
+            vmodel.runner.virt_packet_nus * u.Hz)
+    assert result['virtual_packet_nu'].unit.is_equivalent('Hz')
+    assert result['virtual_packet_energy'].unit.is_equivalent('erg/s')
+
+
+def test_luminosity(input_dict, model, bins):
+    luminosity = Luminosity(bins * u.angstrom)
+    lum_density = np.histogram(
+            model.runner.emitted_packet_nu.to(u.angstrom, u.spectral()),
+            weights=model.runner.emitted_packet_luminosity,
+            bins=bins)[0] / np.diff(bins)
+
+    obtained = luminosity(PacketProvider()({'model': model,}))['luminosity']
+    np.testing.assert_allclose(
+            obtained.value,
+            lum_density)
+    assert obtained.unit.is_equivalent('erg/ (angstrom s)')
+
+
+def test_vluminosity(input_dict, vmodel, bins):
+    vluminosity = VirtualLuminosity(bins * u.angstrom)
+    lum_density = np.histogram(
+            (vmodel.runner.virt_packet_nus*u.Hz).to(u.angstrom, u.spectral()),
+            weights=vmodel.runner.virt_packet_energies /
+            vmodel.runner.time_of_simulation,
+            bins=bins)[0] / np.diff(bins)
+
+    obtained = vluminosity(VirtualPacketProvider()({'model': vmodel,}))['luminosity']
+    np.testing.assert_allclose(obtained.value,
+        lum_density)
+    assert obtained.unit.is_equivalent('erg/ (angstrom s)')
+
+
+def test_flux(model, bins):
+    flux_chain = Chain(PacketProvider(), Luminosity(bins * u.angstrom), Flux())
+    obtained = flux_chain({'model': model})['flux']
+    assert obtained.unit.is_equivalent('erg / (s Angstrom cm2)')

--- a/dalek/util.py
+++ b/dalek/util.py
@@ -1,3 +1,4 @@
+import os
 import numpy as np
 from astropy import units as u, constants as const
 # Some helper functions
@@ -17,4 +18,16 @@ def bin_center_to_edge(bin_center):
 
 def bin_edge_to_center(bin_edge):
     return 0.5 * (bin_edge[:-1] + bin_edge[1:] )
+
+def set_engines_cpu_affinity():
+    import sys
+    if sys.platform.startswith('linux'):
+        try:
+            import psutil
+        except ImportError:
+            print 'psutil not available - can not set CPU affinity'
+        else:
+            from multiprocessing import cpu_count
+            p = psutil.Process(os.getpid())
+            p.cpu_affinity(range(cpu_count()))
 

--- a/dalek/util.py
+++ b/dalek/util.py
@@ -1,0 +1,20 @@
+import numpy as np
+from astropy import units as u, constants as const
+# Some helper functions
+
+def intensity_black_body_wavelength(wavelength, T):
+    wavelength = u.Quantity(wavelength, u.angstrom)
+    T = u.Quantity(T, u.K)
+    f = ((8 * np.pi * const.h * const.c) / wavelength**5)
+    return f / (np.exp((const.h * const.c)/(wavelength * const.k_B * T)) - 1)
+
+def bin_center_to_edge(bin_center):
+    hdiff = 0.5 * np.diff(bin_center)
+    hdiff = np.hstack((-hdiff[0], hdiff, hdiff[-1]))
+    return np.hstack((
+        bin_center[0],
+        bin_center)) + hdiff
+
+def bin_edge_to_center(bin_edge):
+    return 0.5 * (bin_edge[:-1] + bin_edge[1:] )
+

--- a/dalek/wrapper/__init__.py
+++ b/dalek/wrapper/__init__.py
@@ -1,0 +1,1 @@
+from hdfstore import SafeHDFStore

--- a/dalek/wrapper/hdfstore.py
+++ b/dalek/wrapper/hdfstore.py
@@ -1,0 +1,33 @@
+import os
+import time
+import errno
+import logging
+
+from pandas import HDFStore
+
+logger = logging.getLogger(__name__)
+
+
+class SafeHDFStore(HDFStore):
+    def __init__(self, *args, **kwargs):
+        probe_interval = kwargs.pop("probe_interval", 1)
+        self._lock = "%s.lock" % args[0]
+        while True:
+            try:
+                self._flock = os.open(self._lock, os.O_CREAT |
+                                                  os.O_EXCL |
+                                                  os.O_WRONLY)
+                break
+            except OSError as e:
+                if e.errno == errno.EEXIST:
+                    time.sleep(probe_interval)
+                else:
+                    raise e
+
+        HDFStore.__init__(self, *args, **kwargs)
+
+    def __exit__(self, *args, **kwargs):
+        logger.debug('Exit SafeHDFStore')
+        HDFStore.__exit__(self, *args, **kwargs)
+        os.close(self._flock)
+        os.remove(self._lock)

--- a/dalek/wrapper/tardis_wrapper.py
+++ b/dalek/wrapper/tardis_wrapper.py
@@ -1,0 +1,80 @@
+
+# coding: utf-8
+
+# In[54]:
+
+import os
+import logging
+
+from uuid import uuid4
+from copy import deepcopy
+
+from tardis.atomic import AtomData
+from tardis.model import Radial1DModel
+from tardis.simulation import run_radial1d
+from tardis.io.config_reader import Configuration, ConfigurationNameSpace
+
+from dalek.base.simulation import TinnerSimulation
+
+class TardisWrapper(object):
+
+    def __init__(self, config_fname, atom_data=None, log_dir='./logs/'):
+        self._log_dir = log_dir
+        self.set_logger('startup')
+        self._config = ConfigurationNameSpace.from_yaml(config_fname)
+        if atom_data is None:
+            self._atom_data = AtomData.from_hdf5(self._config.atom_data)
+        else:
+            self._atom_data = atom_data
+
+
+    def __call__(self, callback, log_name=None):
+        if log_name is None:
+            self.uuid = uuid4()
+            self.set_logger(self.uuid)
+        config = self._generate_config(callback)
+        self.model = self.run_tardis(config)
+        return self.model
+
+    def _generate_config(self, callback):
+        config_ns = callback(self.config)
+        return Configuration.from_config_dict(
+                config_ns,
+                validate=False,
+                atom_data=self.atom_data)
+
+    def set_logger(self, name):
+        filename = os.path.join(self._log_dir, 'tardis_{}.log'.format(name))
+        self._set_logger(filename)
+
+    def _set_logger(self, filename):
+        tardis_logger = logging.getLogger('tardis')
+        tardis_logger.setLevel(logging.INFO)
+        fileHandler = logging.FileHandler(filename)
+        tardis_logger.handlers = [fileHandler]
+
+    def run_tardis(self, config):
+        mdl = Radial1DModel(config)
+        run_radial1d(mdl)
+        return mdl
+
+
+    @property
+    def atom_data(self):
+        return deepcopy(self._atom_data)
+
+    @property
+    def config(self):
+        return deepcopy(self._config)
+
+
+class TInnerWrapper(TardisWrapper):
+
+    def run_tardis(self, config):
+        mdl = Radial1DModel(config)
+        t_inner = config.get_config_item('plasma.t_inner')
+        simulation = TinnerSimulation(config)
+        simulation.run_simulation(mdl, t_inner)
+        mdl.runner = simulation.runner
+        return mdl
+

--- a/dalek/wrapper/tardis_wrapper.py
+++ b/dalek/wrapper/tardis_wrapper.py
@@ -30,8 +30,8 @@ class TardisWrapper(object):
 
     def __call__(self, callback, log_name=None):
         if log_name is None:
-            self.uuid = uuid4()
-            self.set_logger(self.uuid)
+            log_name = uuid4()
+        self.set_logger(log_name)
         config = self._generate_config(callback)
         self.model = self.run_tardis(config)
         return self.model


### PR DESCRIPTION
These can be used to store arbitary information about one set of dalek runs in
a .h5 file.
Currently the workflow is the following. One needs to create one instance of
MetaContainer which accepts additional 'summary_data' that will be added to the
.h5 file as a series.

Information can then be added the container by creating an instance of
MetaInformation and calling MetaInformation.save(MetaContainer).
MetaInformation(uuid, rank, iteration, fitness, additional_data) is the call
structure where additional_data is a dictionary of key-value pairs (for example
the parameters of a specific dalek run). Additional data can be added with
MetaInformation.add_data(name, data) where data has to support the .to_hdf calling
convention.

MetaContainer should provide thread and process save access to the .h5 file but
this hasn't been tested yet.